### PR TITLE
Job should end on error in task execution

### DIFF
--- a/lib/jobmon/rake_monitor.rb
+++ b/lib/jobmon/rake_monitor.rb
@@ -13,8 +13,11 @@ module Jobmon
       args, estimate_time = resolve_args(args)
       task *args do |t|
         job_id = client.job_start(t, estimate_time)
-        block.call(t)
-        client.job_end(job_id)
+        begin
+          block.call(t)
+        ensure
+          client.job_end(job_id)
+        end
       end
     end
   end

--- a/spec/jobmon/rake_monitor_spec.rb
+++ b/spec/jobmon/rake_monitor_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'ostruct'
+
+require 'jobmon/rake_monitor'
+
+describe Jobmon::RakeMonitor do
+  module SampleModule
+    extend Jobmon::RakeMonitor
+
+    SampleTask = Struct.new(:name)
+
+    def self.client=(client)
+      @client = client
+    end
+
+    def self.task(*)
+      yield SampleTask.new('test')
+    end
+  end
+
+  context 'without error' do
+    it 'calls #job_start and #job_end' do
+      client = Jobmon::Client.new
+      expect(client).to receive(:job_start).once
+      expect(client).to receive(:job_end).once
+      SampleModule.client = client
+      SampleModule.task_with_monitor(sample: :development, estimate_time: 10.minutes) {}
+    end
+  end
+
+  context 'with error' do
+    it 'calls #job_start and #job_end and raise error' do
+      client = Jobmon::Client.new
+      expect(client).to receive(:job_start).once
+      expect(client).to receive(:job_end).once
+      SampleModule.client = client
+      expect {
+        SampleModule.task_with_monitor(sample: :development, estimate_time: 10.minutes) { raise 'test' }
+      }.to raise_error(RuntimeError, 'test')
+    end
+  end
+end


### PR DESCRIPTION
BEFORE

- Job is still "running" even when error raises in task execution.

AFTER

- Job is marked as "finished" when error raises in task execution.