### PR TITLE
[review] rake のタスクが load される前に config/initializers/jobmon.rb が require されるように修正

### DIFF
--- a/lib/jobmon/rake_monitor.rb
+++ b/lib/jobmon/rake_monitor.rb
@@ -1,8 +1,11 @@
 module Jobmon
   module RakeMonitor
     def resolve_args(args)
-      estimate_time = args.first.delete(:estimate_time)
-      [args, estimate_time]
+      options = args.first
+      estimate_time = options.delete(:estimate_time)
+      skip_jobmon_available_check = options.delete(:skip_jobmon_available_check)
+
+      [args, { estimate_time: estimate_time, skip_jobmon_available_check: skip_jobmon_available_check }]
     end
 
     def client
@@ -10,11 +13,11 @@ module Jobmon
     end
 
     def task_with_monitor(*args, &block)
-      args, estimate_time = resolve_args(args)
+      args, options = resolve_args(args)
 
-      if Jobmon.available?
+      if Jobmon.available? || options[:skip_jobmon_available_check]
         task *args do |t|
-          job_id = client.job_start(t, estimate_time)
+          job_id = client.job_start(t, options[:estimate_time])
           log(t, job_id, :started)
           begin
             block.call(t)

--- a/lib/jobmon/tasks/preload.rb
+++ b/lib/jobmon/tasks/preload.rb
@@ -1,2 +1,7 @@
 require 'jobmon/client'
 require 'jobmon/rake_monitor'
+
+config_file = Rails.root.join('config/initializers/jobmon.rb')
+if File.exists?(config_file)
+  require config_file
+end

--- a/lib/jobmon/tasks/test.rake
+++ b/lib/jobmon/tasks/test.rake
@@ -1,5 +1,5 @@
 namespace :jobmon do
   desc 'Send a test job to job-mon'
-  task_with_monitor test_job: :environment, estimate_time: 10 do
+  task_with_monitor test_job: :environment, estimate_time: 10, skip_jobmon_available_check: true do
   end
 end

--- a/lib/jobmon/version.rb
+++ b/lib/jobmon/version.rb
@@ -1,3 +1,3 @@
 module Jobmon
-  VERSION = "0.2.3.2"
+  VERSION = "0.2.4"
 end

--- a/lib/jobmon/version.rb
+++ b/lib/jobmon/version.rb
@@ -1,3 +1,3 @@
 module Jobmon
-  VERSION = "0.2.3.1"
+  VERSION = "0.2.3.2"
 end


### PR DESCRIPTION
`jobmon:test_job` が実行できなくて、原因を調べたら、
`config/initializers/jobmon.rb` をロードする前に rake のタスクが読み込まれ `available_release_stagings` が反映されないためであったので修正。