### PR TITLE
[review] 不要なinitializersの読み込み削除

### DIFF
--- a/lib/jobmon/tasks/preload.rb
+++ b/lib/jobmon/tasks/preload.rb
@@ -1,7 +1,2 @@
 require 'jobmon/client'
 require 'jobmon/rake_monitor'
-
-config_file = Rails.root.join('config/initializers/jobmon.rb')
-if File.exists?(config_file)
-  require config_file
-end


### PR DESCRIPTION
#13 で入れたっぽいけど、https://github.com/SonicGarden/jobmon_ruby/commit/e57cc7a30a4dc8cefae1da2b447163f25e0ad820 で不要になっているし標準の動きからも逸れていて気になったので、、ｗ