### PR TITLE
[WIP] faraday の代わりに net/http を使うように

### DIFF
--- a/jobmon.gemspec
+++ b/jobmon.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rails'
-  spec.add_dependency 'faraday', "~> 2.0"
   spec.add_dependency "retryable"
   spec.add_dependency 'rake', '>= 12.2.0'
   spec.add_dependency 'activesupport'

--- a/lib/jobmon.rb
+++ b/lib/jobmon.rb
@@ -1,7 +1,6 @@
 require 'rails'
 require 'rake'
 require 'active_support/all'
-require 'faraday'
 require 'jobmon/version'
 require 'jobmon/client'
 require 'jobmon/engine'

--- a/lib/jobmon/client.rb
+++ b/lib/jobmon/client.rb
@@ -1,16 +1,12 @@
 require 'retryable'
 require 'securerandom'
+require 'jobmon/http'
 require 'jobmon/errors'
 
 module Jobmon
   class Client
     def conn
-      @conn ||= Faraday.new(url: Jobmon.configuration.endpoint) do |faraday|
-        faraday.request  :url_encoded
-        faraday.request  :json
-        faraday.response :json
-        faraday.adapter  Faraday.default_adapter
-      end
+      @conn ||= Http.json(Jobmon.configuration.endpoint)
     end
 
     def api_key
@@ -49,8 +45,8 @@ module Jobmon
           },
           request_uuid: request_uuid,
         }
-        response = conn.post "/api/apps/#{api_key}/jobs.json", body
-        response.body['id']
+        response = conn.post "/api/apps/#{api_key}/jobs.json", JSON.generate(body)
+        JSON.parse(response.body)['id']
       end
     rescue => e
       logging("Failed to send job_start #{name}", level: :warn)
@@ -68,7 +64,7 @@ module Jobmon
         }.compact
       }
       Retryable.retryable(tries: 3) do
-        conn.put "/api/apps/#{api_key}/jobs/#{job_id}/finished.json", body
+        conn.put "/api/apps/#{api_key}/jobs/#{job_id}/finished.json", JSON.generate(body)
       end
     rescue => e
       logging("Failed to send job_end #{name}", level: :warn)
@@ -83,8 +79,8 @@ module Jobmon
           rails_env: Jobmon.configuration.release_stage,
         }
       }
-      response = conn.post "/api/apps/#{api_key}/queue_logs.json", body
-      response.body['id']
+      response = conn.post "/api/apps/#{api_key}/queue_logs.json", JSON.generate(body)
+      JSON.parse(response.body)['id']
     rescue => e
       logging("Failed to send send_queue_log", level: :warn)
       Jobmon.configuration.error_handle.call(Jobmon::RequestError.new(e))

--- a/lib/jobmon/http.rb
+++ b/lib/jobmon/http.rb
@@ -1,0 +1,46 @@
+require 'net/http'
+
+module Jobmon
+  class Http
+    class << self
+      def json(endpoint)
+        default_headers = {
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json'
+        }
+        new(endpoint, default_headers)
+      end
+    end
+
+    def initialize(endpoint, default_headers = {})
+      @endpoint_uri = URI(endpoint)
+      @default_headers = default_headers
+    end
+
+    def post(path, body)
+      req = initialize_request(Net::HTTP::Post.new(path), body)
+      net_http.request(req)
+    end
+
+    def put(path, body)
+      req = initialize_request(Net::HTTP::Put.new(path), body)
+      net_http.request(req)
+    end
+
+    private
+
+    def net_http
+      http = Net::HTTP.new(@endpoint_uri.hostname, @endpoint_uri.port)
+      http.use_ssl = @endpoint_uri.scheme == 'https'
+      http
+    end
+
+    def initialize_request(request, body)
+      @default_headers.each do |k, v|
+        request.add_field(k, v)
+      end
+      request.body = body
+      request
+    end
+  end
+end


### PR DESCRIPTION
- httpクライアントとして faraday の代わりに net/http を使うように変更
- アプリケーションで faraday を v1 系に固定していると jobmon_ruby を更新できないため